### PR TITLE
Add devcontainer and Docker build config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0
+
+# Install any additional dependencies here
+RUN apt-get update \
+    && apt-get install -y git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "MoMoney",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "workspaceFolder": "/workspace/MoMoney",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp"
+            ]
+        }
+    },
+    "postCreateCommand": "dotnet restore MoMoney.sln"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0 AS build
+WORKDIR /src
+COPY . ./
+RUN dotnet restore MoMoney.sln
+RUN dotnet publish Website/Retire.csproj -c Release -o /app/Website
+RUN dotnet publish ConsoleApp/Money.csproj -c Release -o /app/ConsoleApp
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:9.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/Website ./Website
+COPY --from=build /app/ConsoleApp ./ConsoleApp
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Website/Retire.dll"]

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,7 @@
+image:
+  name: mcr.microsoft.com/dotnet/nightly/sdk:9.0
+  dockerfile: Dockerfile
+workdir: /workspace/MoMoney
+steps:
+  - run: dotnet restore MoMoney.sln
+  - run: dotnet build MoMoney.sln --configuration Release --no-restore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_URLS: http://+:8080


### PR DESCRIPTION
## Summary
- add Dockerfile for publishing the Console and Blazor projects
- set up docker-compose to run the web site
- add devcontainer with .NET 9 SDK
- add `codex.yaml` to describe how to build the solution

## Testing
- `~/dotnet/dotnet restore MoMoney.sln`
- `~/dotnet/dotnet build MoMoney.sln -c Release --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6872b3a3daf483249f9decdf7c62736a