### PR TITLE
Fix cascade delete for rollovers

### DIFF
--- a/Website/Data/RetirementPlannerContext.cs
+++ b/Website/Data/RetirementPlannerContext.cs
@@ -69,5 +69,17 @@ public class RetirementPlannerContext : DbContext
         modelBuilder.Entity<InvestmentRollover>()
             .Property(r => r.RolloverType)
             .HasConversion<string>();
+
+        modelBuilder.Entity<InvestmentRollover>()
+            .HasOne(r => r.SourceInvestment)
+            .WithMany()
+            .HasForeignKey(r => r.SourceInvestmentId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<InvestmentRollover>()
+            .HasOne(r => r.DestinationInvestment)
+            .WithMany()
+            .HasForeignKey(r => r.DestinationInvestmentId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Website/Migrations/20250713194203_initial.Designer.cs
+++ b/Website/Migrations/20250713194203_initial.Designer.cs
@@ -382,13 +382,13 @@ namespace Retire.Migrations
                     b.HasOne("RetirementPlanner.Models.Investment", "DestinationInvestment")
                         .WithMany()
                         .HasForeignKey("DestinationInvestmentId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("RetirementPlanner.Models.Investment", "SourceInvestment")
                         .WithMany()
                         .HasForeignKey("SourceInvestmentId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("DestinationInvestment");

--- a/Website/Migrations/20250713194203_initial.cs
+++ b/Website/Migrations/20250713194203_initial.cs
@@ -177,13 +177,13 @@ namespace Retire.Migrations
                         column: x => x.DestinationInvestmentId,
                         principalTable: "Investments",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_InvestmentRollovers_Investments_SourceInvestmentId",
                         column: x => x.SourceInvestmentId,
                         principalTable: "Investments",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(


### PR DESCRIPTION
## Summary
- prevent multi-cascade paths for `InvestmentRollover`
- update initial migration to use `Restrict` delete behavior

## Testing
- `dotnet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687409c563248324b7d8b43095c3c029