### PR TITLE
Fix cascade delete error in InvestmentRollovers

### DIFF
--- a/Website/Migrations/20250713195322_FixCascadeDelete.Designer.cs
+++ b/Website/Migrations/20250713195322_FixCascadeDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RetirementPlanner.Data;
 
@@ -11,9 +12,11 @@ using RetirementPlanner.Data;
 namespace Retire.Migrations
 {
     [DbContext(typeof(RetirementPlannerContext))]
-    partial class RetirementPlannerContextModelSnapshot : ModelSnapshot
+    [Migration("20250713195322_FixCascadeDelete")]
+    partial class FixCascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Website/Migrations/20250713195322_FixCascadeDelete.cs
+++ b/Website/Migrations/20250713195322_FixCascadeDelete.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Retire.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixCascadeDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_InvestmentRollovers_Investments_DestinationInvestmentId",
+                table: "InvestmentRollovers");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_InvestmentRollovers_Investments_SourceInvestmentId",
+                table: "InvestmentRollovers");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InvestmentRollovers_Investments_DestinationInvestmentId",
+                table: "InvestmentRollovers",
+                column: "DestinationInvestmentId",
+                principalTable: "Investments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InvestmentRollovers_Investments_SourceInvestmentId",
+                table: "InvestmentRollovers",
+                column: "SourceInvestmentId",
+                principalTable: "Investments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_InvestmentRollovers_Investments_DestinationInvestmentId",
+                table: "InvestmentRollovers");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_InvestmentRollovers_Investments_SourceInvestmentId",
+                table: "InvestmentRollovers");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InvestmentRollovers_Investments_DestinationInvestmentId",
+                table: "InvestmentRollovers",
+                column: "DestinationInvestmentId",
+                principalTable: "Investments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InvestmentRollovers_Investments_SourceInvestmentId",
+                table: "InvestmentRollovers",
+                column: "SourceInvestmentId",
+                principalTable: "Investments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add migration to change InvestmentRollovers FK delete behavior to `Restrict`

## Testing
- `dotnet restore MoMoney.sln`
- `dotnet build MoMoney.sln --configuration Release --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68740dd97bbc8324890b91755675a072