### PR TITLE
Fix missing layout in App component

### DIFF
--- a/Website/Components/App.razor
+++ b/Website/Components/App.razor
@@ -13,7 +13,12 @@
 </head>
 
 <body>
-    <Routes @rendermode="InteractiveServer" />
+    <Router AppAssembly="typeof(Program).Assembly" @rendermode="InteractiveServer">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" DefaultLayout="typeof(Shared.MainLayout)" />
+            <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        </Found>
+    </Router>
     <script src="_framework/blazor.web.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- set `MainLayout` as the default layout by replacing `<Routes>` usage with a `Router` that specifies `DefaultLayout`

## Testing
- `dotnet build MoMoney.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68741da724f08324bfffe35821496448