### PR TITLE
Fix nav display for home page

### DIFF
--- a/Website/Components/Shared/MainLayout.razor
+++ b/Website/Components/Shared/MainLayout.razor
@@ -1,7 +1,7 @@
 @inherits LayoutComponentBase
 
 <div class="flex min-h-screen">
-    <div class="@GetNavClass()" style="@(showNav ? "display:block;" : "display:none;")">
+    <div class="@GetNavClass() @(showNav ? "" : "hidden")">
         <NavMenu />
     </div>
 


### PR DESCRIPTION
## Summary
- adjust `MainLayout.razor` so nav menu shows on larger screens and toggles on mobile

## Testing
- `dotnet build Website/Retire.csproj --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742115a6708324995d765ca52f4dad