### PR TITLE
Improve modal and UI styling

### DIFF
--- a/Website/Components/Shared/MainLayout.razor
+++ b/Website/Components/Shared/MainLayout.razor
@@ -5,7 +5,7 @@
         <NavMenu />
     </div>
 
-    <div class="flex-1 bg-gray-50 text-gray-900">
+    <div class="flex-1 bg-gradient-to-r from-white via-blue-50 to-white text-gray-900">
         <header class="bg-white p-4 flex md:hidden border-b border-gray-200">
             <button @onclick="ToggleNav" class="text-gray-700">☰</button>
         </header>

--- a/Website/Components/Shared/NavMenu.razor
+++ b/Website/Components/Shared/NavMenu.razor
@@ -1,12 +1,12 @@
-<nav class="space-y-2">
-    <NavLink href="" Match="NavLinkMatch.All" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Home</NavLink>
-    <NavLink href="people" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">People</NavLink>
-    <NavLink href="investments" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Investments</NavLink>
-    <NavLink href="incomes" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Incomes</NavLink>
-    <NavLink href="expenses" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Expenses</NavLink>
-    <NavLink href="assets" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Assets</NavLink>
-    <NavLink href="taxbrackets" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Tax Brackets</NavLink>
-    <NavLink href="rollovers" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Rollovers</NavLink>
-    <NavLink href="surplusallocations" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Surplus Allocations</NavLink>
-    <NavLink href="scenarios" class="block px-3 py-2 rounded text-gray-800 bg-white hover:bg-gray-100 font-medium">Scenarios</NavLink>
+<nav class="space-y-2 bg-gradient-to-b from-blue-600 to-blue-800 p-2 rounded">
+    <NavLink href="" Match="NavLinkMatch.All" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Home</NavLink>
+    <NavLink href="people" class="block px-3 py-2 rounded text-white hover:bg-blue-700">People</NavLink>
+    <NavLink href="investments" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Investments</NavLink>
+    <NavLink href="incomes" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Incomes</NavLink>
+    <NavLink href="expenses" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Expenses</NavLink>
+    <NavLink href="assets" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Assets</NavLink>
+    <NavLink href="taxbrackets" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Tax Brackets</NavLink>
+    <NavLink href="rollovers" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Rollovers</NavLink>
+    <NavLink href="surplusallocations" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Surplus Allocations</NavLink>
+    <NavLink href="scenarios" class="block px-3 py-2 rounded text-white hover:bg-blue-700">Scenarios</NavLink>
 </nav>

--- a/Website/Pages/Assets.razor
+++ b/Website/Pages/Assets.razor
@@ -42,18 +42,18 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingAsset.Id == 0 ? "Add" : "Edit") Asset</h2>
             <EditForm Model="_editingAsset" OnValidSubmit="SaveAsset">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Name <span class="info-icon" title="Name of the asset">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Name of the asset">ⓘ</span> Name</label>
                     <InputText class="form-input" @bind-Value="_editingAsset.Name" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Value <span class="info-icon" title="Current value of the asset">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Current value of the asset">ⓘ</span> Value</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingAsset.Value" />
                     </div>
@@ -77,7 +77,7 @@ else
                     </label>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Appreciation Rate <span class="info-icon" title="Annual appreciation percentage">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Annual appreciation percentage">ⓘ</span> Appreciation Rate</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingAsset.AppreciationRate" />
                     </div>

--- a/Website/Pages/Expenses.razor
+++ b/Website/Pages/Expenses.razor
@@ -69,18 +69,18 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingExpense.Id == 0 ? "Add" : "Edit") Expense</h2>
             <EditForm Model="_editingExpense" OnValidSubmit="SaveExpense">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Category <span class="info-icon" title="Expense category">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Expense category">ⓘ</span> Category</label>
                     <InputText class="form-input" @bind-Value="_editingExpense.Category" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Amount <span class="info-icon" title="Annual expense amount">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Annual expense amount">ⓘ</span> Amount</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingExpense.AnnualAmount" />
                     </div>
@@ -92,15 +92,15 @@ else
                     </label>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Start Year <span class="info-icon" title="Year the expense begins">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Year the expense begins">ⓘ</span> Start Year</label>
                     <InputNumber class="form-input" @bind-Value="_editingExpense.StartYear" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">End Year <span class="info-icon" title="Year the expense ends">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Year the expense ends">ⓘ</span> End Year</label>
                     <InputNumber class="form-input" @bind-Value="_editingExpense.EndYear" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Notes <span class="info-icon" title="Additional notes">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Additional notes">ⓘ</span> Notes</label>
                     <InputText class="form-input" @bind-Value="_editingExpense.Notes" />
                 </div>
                 <div class="flex justify-end space-x-2">

--- a/Website/Pages/Incomes.razor
+++ b/Website/Pages/Incomes.razor
@@ -42,19 +42,19 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingIncome.Id == 0 ? "Add" : "Edit") Income</h2>
             <EditForm Model="_editingIncome" OnValidSubmit="SaveIncome">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Source <span class="info-icon" title="Income source">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Income source">ⓘ</span> Source</label>
                     <InputText class="form-input" @bind-Value="_editingIncome.Source" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Type <span class="info-icon" title="Income type">ⓘ</span></label>
-                    <InputSelect class="border rounded w-full" @bind-Value="_editingIncome.IncomeType">
+                    <label class="form-label"><span class="info-icon" title="Income type">ⓘ</span> Type</label>
+                    <InputSelect class="form-input" @bind-Value="_editingIncome.IncomeType">
                         @foreach (var val in Enum.GetValues<IncomeType>())
                         {
                             <option value="@val">@val</option>
@@ -62,7 +62,7 @@ else
                     </InputSelect>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Amount <span class="info-icon" title="Annual income amount">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Annual income amount">ⓘ</span> Amount</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingIncome.AnnualAmount" />
                     </div>
@@ -74,15 +74,15 @@ else
                     </label>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Start Year <span class="info-icon" title="Year income begins">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Year income begins">ⓘ</span> Start Year</label>
                     <InputNumber class="form-input" @bind-Value="_editingIncome.StartYear" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">End Year <span class="info-icon" title="Year income ends">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Year income ends">ⓘ</span> End Year</label>
                     <InputNumber class="form-input" @bind-Value="_editingIncome.EndYear" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Person Id <span class="info-icon" title="Linked person">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Linked person">ⓘ</span> Person Id</label>
                     <InputNumber class="form-input" @bind-Value="_editingIncome.PersonId" />
                 </div>
                 <div class="flex justify-end space-x-2">

--- a/Website/Pages/InvestmentRollovers.razor
+++ b/Website/Pages/InvestmentRollovers.razor
@@ -44,33 +44,33 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingRollover.Id == 0 ? "Add" : "Edit") Rollover</h2>
             <EditForm Model="_editingRollover" OnValidSubmit="SaveRollover">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Source Investment Id <span class="info-icon" title="Source investment">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Source investment">ⓘ</span> Source Investment Id</label>
                     <InputNumber class="form-input" @bind-Value="_editingRollover.SourceInvestmentId" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Destination Investment Id <span class="info-icon" title="Destination investment">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Destination investment">ⓘ</span> Destination Investment Id</label>
                     <InputNumber class="form-input" @bind-Value="_editingRollover.DestinationInvestmentId" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Amount <span class="info-icon" title="Rollover amount">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Rollover amount">ⓘ</span> Amount</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingRollover.Amount" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Year <span class="info-icon" title="Year of rollover">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Year of rollover">ⓘ</span> Year</label>
                     <InputNumber class="form-input" @bind-Value="_editingRollover.Year" />
                 </div>
                 <div class="mb-2">
                     <label class="block text-sm font-medium">Rollover Type</label>
-                    <InputSelect class="border rounded w-full" @bind-Value="_editingRollover.RolloverType">
+                    <InputSelect class="form-input" @bind-Value="_editingRollover.RolloverType">
                         @foreach (var val in Enum.GetValues<RolloverType>())
                         {
                             <option value="@val">@val</option>

--- a/Website/Pages/Investments.razor
+++ b/Website/Pages/Investments.razor
@@ -45,19 +45,19 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingInvestment.Id == 0 ? "Add" : "Edit") Investment</h2>
             <EditForm Model="_editingInvestment" OnValidSubmit="SaveInvestment">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Name <span class="info-icon" title="Investment name">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="This is the field we use for display within lists, it is a user friendly name to identify the investment.">ⓘ</span> Name</label>
                     <InputText class="form-input" @bind-Value="_editingInvestment.Name" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Type <span class="info-icon" title="Investment type">ⓘ</span></label>
-                    <InputSelect class="border rounded w-full" @bind-Value="_editingInvestment.InvestmentType">
+                    <label class="form-label"><span class="info-icon" title="Investment type">ⓘ</span> Type</label>
+                    <InputSelect class="form-input" @bind-Value="_editingInvestment.InvestmentType">
                         @foreach (var val in Enum.GetValues<InvestmentType>())
                         {
                             <option value="@val">@val</option>
@@ -65,37 +65,37 @@ else
                     </InputSelect>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Current Balance <span class="info-icon" title="Current balance">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Current balance">ⓘ</span> Current Balance</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.CurrentBalance" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Expected Dividend Yield <span class="info-icon" title="Dividend yield percent">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Dividend yield percent">ⓘ</span> Expected Dividend Yield</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.ExpectedDividendYield" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Expected Growth Rate <span class="info-icon" title="Growth rate percent">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Growth rate percent">ⓘ</span> Expected Growth Rate</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.ExpectedGrowthRate" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Return of Capital Rate <span class="info-icon" title="Return of capital percent">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Return of capital percent">ⓘ</span> Return of Capital Rate</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.ExpectedReturnOfCapitalRate" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Expense Ratio <span class="info-icon" title="Expense ratio percent">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Expense ratio percent">ⓘ</span> Expense Ratio</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.ExpenseRatio" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Turnover Rate <span class="info-icon" title="Turnover rate percent">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="This is the percentage of your portfolio which is expected to be sold in any given year. This is used to help calculate Capital Gains.">ⓘ</span> Turnover Rate</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.ExpectedTurnoverRate" />
                     </div>
@@ -113,7 +113,7 @@ else
                     </label>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Withdrawal Priority <span class="info-icon" title="Priority for withdrawals">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Priority for withdrawals">ⓘ</span> Withdrawal Priority</label>
                     <InputNumber class="form-input" @bind-Value="_editingInvestment.WithdrawalPriority" />
                 </div>
                 <div class="mb-2">
@@ -125,12 +125,12 @@ else
                 @if (ShowRmdStartAge)
                 {
                     <div class="mb-2">
-                        <label class="form-label">RMD Start Age <span class="info-icon" title="Age RMDs begin">ⓘ</span></label>
+                        <label class="form-label"><span class="info-icon" title="Age RMDs begin">ⓘ</span> RMD Start Age</label>
                         <InputNumber class="form-input" @bind-Value="_editingInvestment.RMDStartAge" />
                     </div>
                 }
                 <div class="mb-2">
-                    <label class="form-label">Person Id <span class="info-icon" title="Owner">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Owner">ⓘ</span> Person Id</label>
                     <InputNumber class="form-input" @bind-Value="_editingInvestment.PersonId" />
                 </div>
                 <div class="flex justify-end space-x-2">

--- a/Website/Pages/People.razor
+++ b/Website/Pages/People.razor
@@ -68,7 +68,7 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center z-50">
         <div class="bg-white rounded-lg shadow-lg w-full max-w-md border border-blue-200">
             <div class="flex items-center justify-between px-4 py-3 border-b border-blue-100 bg-blue-50 rounded-t-lg">
                 <h2 class="text-xl font-bold text-blue-900">@(_editingPerson.Id == 0 ? "Add" : "Edit") Person</h2>
@@ -79,11 +79,11 @@ else
                     <DataAnnotationsValidator />
                     <ValidationSummary />
                     <div class="mb-4">
-                        <label class="form-label">Name <span class="info-icon" title="Person's name">ⓘ</span></label>
+                        <label class="form-label"><span class="info-icon" title="Person's name">ⓘ</span> Name</label>
                         <InputText class="form-input" @bind-Value="_editingPerson.Name" />
                     </div>
                     <div class="mb-4">
-                        <label class="form-label">Birth Date <span class="info-icon" title="Date of birth">ⓘ</span></label>
+                        <label class="form-label"><span class="info-icon" title="Date of birth">ⓘ</span> Birth Date</label>
                         <InputDate @bind-Value="_editingPerson.BirthDate" class="form-input" />
                     </div>
                     <div class="flex justify-end space-x-2 mt-4">

--- a/Website/Pages/SurplusAllocations.razor
+++ b/Website/Pages/SurplusAllocations.razor
@@ -42,18 +42,18 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingAllocation.Id == 0 ? "Add" : "Edit") Allocation</h2>
             <EditForm Model="_editingAllocation" OnValidSubmit="SaveAllocation">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Investment Id <span class="info-icon" title="Investment identifier">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Investment identifier">ⓘ</span> Investment Id</label>
                     <InputNumber class="form-input" @bind-Value="_editingAllocation.InvestmentId" />
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Percentage <span class="info-icon" title="Allocation percentage">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Allocation percentage">ⓘ</span> Percentage</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingAllocation.AllocationPercentage" />
                     </div>

--- a/Website/Pages/TaxBrackets.razor
+++ b/Website/Pages/TaxBrackets.razor
@@ -46,15 +46,15 @@ else
 
 @if (IsModalOpen)
 {
-    <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
         <div class="bg-white p-4 rounded shadow w-full max-w-md">
             <h2 class="text-xl font-bold mb-2">@(_editingBracket.Id == 0 ? "Add" : "Edit") Tax Bracket</h2>
             <EditForm Model="_editingBracket" OnValidSubmit="SaveBracket">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
                 <div class="mb-2">
-                    <label class="form-label">Type <span class="info-icon" title="Type of tax">ⓘ</span></label>
-                    <InputSelect class="border rounded w-full" @bind-Value="_editingBracket.TaxType">
+                    <label class="form-label"><span class="info-icon" title="Type of tax">ⓘ</span> Type</label>
+                    <InputSelect class="form-input" @bind-Value="_editingBracket.TaxType">
                         @foreach (var val in Enum.GetValues<TaxType>())
                         {
                             <option value="@val">@val</option>
@@ -62,8 +62,8 @@ else
                     </InputSelect>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Filing Status <span class="info-icon" title="Tax filing status">ⓘ</span></label>
-                    <InputSelect class="border rounded w-full" @bind-Value="_editingBracket.FilingStatus">
+                    <label class="form-label"><span class="info-icon" title="Tax filing status">ⓘ</span> Filing Status</label>
+                    <InputSelect class="form-input" @bind-Value="_editingBracket.FilingStatus">
                         @foreach (var val in Enum.GetValues<FilingStatus>())
                         {
                             <option value="@val">@val</option>
@@ -71,31 +71,31 @@ else
                     </InputSelect>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Min Income <span class="info-icon" title="Minimum income for bracket">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Minimum income for bracket">ⓘ</span> Min Income</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingBracket.MinIncome" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Max Income <span class="info-icon" title="Maximum income for bracket">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Maximum income for bracket">ⓘ</span> Max Income</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingBracket.MaxIncome" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Rate <span class="info-icon" title="Tax rate">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Tax rate">ⓘ</span> Rate</label>
                     <div class="percentage-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingBracket.Rate" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">Threshold <span class="info-icon" title="Additional threshold">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="Additional threshold">ⓘ</span> Threshold</label>
                     <div class="currency-wrapper">
                         <InputNumber class="form-input" @bind-Value="_editingBracket.Threshold" />
                     </div>
                 </div>
                 <div class="mb-2">
-                    <label class="form-label">State <span class="info-icon" title="State code">ⓘ</span></label>
+                    <label class="form-label"><span class="info-icon" title="State code">ⓘ</span> State</label>
                     <InputText class="form-input" @bind-Value="_editingBracket.State" />
                 </div>
                 <div class="flex justify-end space-x-2">

--- a/Website/src/input.css
+++ b/Website/src/input.css
@@ -15,6 +15,9 @@
   .form-input {
     @apply border border-gray-300 rounded w-full px-2 py-1 text-right;
   }
+  select.form-input {
+    @apply border border-gray-300 rounded w-full px-2 py-1 text-left;
+  }
   .form-label {
     @apply block text-sm font-medium mb-1;
   }


### PR DESCRIPTION
## Summary
- blur the backdrop for pop-up modals
- move info icons to the left and add richer descriptions
- apply consistent padding to InputSelect elements
- refresh navigation with a blue gradient and add page gradient
- tweak form styles for selects

## Testing
- `dotnet restore MoMoney.sln` *(fails: .NET SDK doesn't support target framework)*
- `dotnet build MoMoney.sln --configuration Release --no-restore` *(fails: .NET SDK doesn't support target framework)*

------
https://chatgpt.com/codex/tasks/task_e_6875438ed42483248988efd7c9b53dc5