### PR TITLE
Introduce Scenario entity and cloning capability

### DIFF
--- a/Website/Data/RetirementPlannerContext.cs
+++ b/Website/Data/RetirementPlannerContext.cs
@@ -12,6 +12,7 @@ public class RetirementPlannerContext : DbContext
     }
 
     public DbSet<Person> People => Set<Person>();
+    public DbSet<Scenario> Scenarios => Set<Scenario>();
     public DbSet<Investment> Investments => Set<Investment>();
     public DbSet<InvestmentDistributionConfig> InvestmentDistributionConfigs => Set<InvestmentDistributionConfig>();
     public DbSet<Income> Incomes => Set<Income>();
@@ -45,6 +46,10 @@ public class RetirementPlannerContext : DbContext
         modelBuilder.Entity<Person>()
             .Property(p => p.BirthDate)
             .HasColumnType("date");
+
+        modelBuilder.Entity<Scenario>()
+            .Property(s => s.FilingStatus)
+            .HasConversion<string>();
 
         modelBuilder.Entity<Investment>()
             .Property(i => i.InvestmentType)

--- a/Website/Models/Asset.cs
+++ b/Website/Models/Asset.cs
@@ -8,6 +8,10 @@ public class Asset
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [Required, StringLength(100)]
     public string Name { get; set; } = string.Empty;
 

--- a/Website/Models/Expense.cs
+++ b/Website/Models/Expense.cs
@@ -8,6 +8,10 @@ public class Expense
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [Required, StringLength(100)]
     public string Category { get; set; } = string.Empty;
 

--- a/Website/Models/Income.cs
+++ b/Website/Models/Income.cs
@@ -8,6 +8,10 @@ public class Income
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [Required, StringLength(100)]
     public string Source { get; set; } = string.Empty;
 

--- a/Website/Models/Investment.cs
+++ b/Website/Models/Investment.cs
@@ -8,6 +8,10 @@ public class Investment
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [Required, StringLength(100)]
     public string Name { get; set; } = string.Empty;
 

--- a/Website/Models/InvestmentRollover.cs
+++ b/Website/Models/InvestmentRollover.cs
@@ -8,6 +8,10 @@ public class InvestmentRollover
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [ForeignKey("SourceInvestment")]
     public int SourceInvestmentId { get; set; }
     public Investment SourceInvestment { get; set; } = null!;

--- a/Website/Models/Scenario.cs
+++ b/Website/Models/Scenario.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RetirementPlanner.Models;
+
+/// <summary>
+/// Represents a complete set of planning parameters for a single simulation scenario.
+/// </summary>
+public class Scenario
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required, StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public FilingStatus FilingStatus { get; set; } = FilingStatus.Single;
+
+    [StringLength(100)]
+    public string State { get; set; } = string.Empty;
+
+    public int SimulationStartYear { get; set; } = DateTime.UtcNow.Year;
+
+    public int SimulationEndYear { get; set; } = DateTime.UtcNow.Year + 30;
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal GeneralInflationRate { get; set; } = 0.02m;
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal HealthcareInflationRate { get; set; } = 0.04m;
+
+    public virtual ICollection<Investment> Investments { get; set; } = new List<Investment>();
+    public virtual ICollection<Income> Incomes { get; set; } = new List<Income>();
+    public virtual ICollection<Expense> Expenses { get; set; } = new List<Expense>();
+    public virtual ICollection<Asset> Assets { get; set; } = new List<Asset>();
+    public virtual ICollection<TaxBracket> TaxBrackets { get; set; } = new List<TaxBracket>();
+    public virtual ICollection<InvestmentRollover> InvestmentRollovers { get; set; } = new List<InvestmentRollover>();
+    public virtual ICollection<SurplusAllocationConfig> SurplusAllocations { get; set; } = new List<SurplusAllocationConfig>();
+}

--- a/Website/Models/SurplusAllocationConfig.cs
+++ b/Website/Models/SurplusAllocationConfig.cs
@@ -8,6 +8,10 @@ public class SurplusAllocationConfig
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [ForeignKey("Investment")]
     public int InvestmentId { get; set; }
     public Investment Investment { get; set; } = null!;

--- a/Website/Models/TaxBracket.cs
+++ b/Website/Models/TaxBracket.cs
@@ -8,6 +8,10 @@ public class TaxBracket
     [Key]
     public int Id { get; set; }
 
+    [ForeignKey("Scenario")]
+    public int ScenarioId { get; set; }
+    public Scenario Scenario { get; set; } = null!;
+
     [Required]
     public TaxType TaxType { get; set; }
 

--- a/Website/Pages/Assets.razor
+++ b/Website/Pages/Assets.razor
@@ -2,6 +2,7 @@
 @using RetirementPlanner.Models
 @using RetirementPlanner.Services
 @inject IAssetService AssetService
+@inject IScenarioService ScenarioService
 
 <h1 class="text-2xl font-bold mb-4">Assets</h1>
 <button class="px-4 py-2 mb-2 bg-blue-600 text-white rounded" @onclick="OpenAddModal">Add Asset</button>
@@ -93,11 +94,13 @@ else
 
 @code {
     private List<Asset>? _assets;
+    private List<Scenario>? _scenarios;
     private Asset _editingAsset = new();
     private bool IsModalOpen;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadAssets();
     }
 
@@ -106,9 +109,17 @@ else
         _assets = await AssetService.GetAllAsync();
     }
 
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
+    }
+
     private void OpenAddModal()
     {
-        _editingAsset = new Asset();
+        _editingAsset = new Asset
+        {
+            ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0
+        };
         IsModalOpen = true;
     }
 
@@ -123,6 +134,7 @@ else
             IsPrimaryResidence = asset.IsPrimaryResidence,
             IsDepreciable = asset.IsDepreciable,
             AppreciationRate = asset.AppreciationRate
+            ,ScenarioId = asset.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Pages/Expenses.razor
+++ b/Website/Pages/Expenses.razor
@@ -2,6 +2,7 @@
 @using RetirementPlanner.Models
 @using RetirementPlanner.Services
 @inject IExpenseService ExpenseService
+@inject IScenarioService ScenarioService
 
 <div class="mb-6 p-4 bg-gray-100 rounded">
     <h2 class="text-xl font-semibold mb-2">About Expenses</h2>
@@ -114,11 +115,13 @@ else
 
 @code {
     private List<Expense>? _expenses;
+    private List<Scenario>? _scenarios;
     private Expense _editingExpense = new();
     private bool IsModalOpen;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadExpenses();
     }
 
@@ -127,9 +130,14 @@ else
         _expenses = await ExpenseService.GetAllAsync();
     }
 
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
+    }
+
     private void OpenAddModal()
     {
-        _editingExpense = new Expense { StartYear = DateTime.Now.Year };
+        _editingExpense = new Expense { StartYear = DateTime.Now.Year, ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0 };
         IsModalOpen = true;
     }
 
@@ -144,6 +152,7 @@ else
             StartYear = expense.StartYear,
             EndYear = expense.EndYear,
             Notes = expense.Notes
+            ,ScenarioId = expense.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Pages/Incomes.razor
+++ b/Website/Pages/Incomes.razor
@@ -3,6 +3,7 @@
 @using RetirementPlanner.Services
 @inject IIncomeService IncomeService
 @inject IPersonService PersonService
+@inject IScenarioService ScenarioService
 
 <h1 class="text-2xl font-bold mb-4">Incomes</h1>
 <button class="px-4 py-2 mb-2 bg-blue-600 text-white rounded" @onclick="OpenAddModal">Add Income</button>
@@ -104,11 +105,13 @@ else
 @code {
     private List<Income>? _incomes;
     private List<Person>? _people;
+    private List<Scenario>? _scenarios;
     private Income _editingIncome = new();
     private bool IsModalOpen;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadPeople();
         await LoadIncomes();
     }
@@ -116,6 +119,11 @@ else
     private async Task LoadIncomes()
     {
         _incomes = await IncomeService.GetAllAsync();
+    }
+
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
     }
 
     private async Task LoadPeople()
@@ -128,7 +136,8 @@ else
         _editingIncome = new Income
         {
             StartYear = DateTime.Now.Year,
-            PersonId = _people?.FirstOrDefault()?.Id
+            PersonId = _people?.FirstOrDefault()?.Id,
+            ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0
         };
         IsModalOpen = true;
     }
@@ -144,7 +153,8 @@ else
             IsTaxExempt = income.IsTaxExempt,
             StartYear = income.StartYear,
             EndYear = income.EndYear,
-            PersonId = income.PersonId
+            PersonId = income.PersonId,
+            ScenarioId = income.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Pages/InvestmentRollovers.razor
+++ b/Website/Pages/InvestmentRollovers.razor
@@ -3,6 +3,7 @@
 @using RetirementPlanner.Services
 @inject IInvestmentRolloverService InvestmentRolloverService
 @inject IInvestmentService InvestmentService
+@inject IScenarioService ScenarioService
 
 <h1 class="text-2xl font-bold mb-4">Investment Rollovers</h1>
 
@@ -107,11 +108,13 @@ else
 @code {
     private List<InvestmentRollover>? _rollovers;
     private List<Investment>? _investments;
+    private List<Scenario>? _scenarios;
     private InvestmentRollover _editingRollover = new();
     private bool IsModalOpen;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadInvestments();
         await LoadRollovers();
     }
@@ -126,12 +129,18 @@ else
         _investments = await InvestmentService.GetAllAsync();
     }
 
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
+    }
+
     private void OpenAddModal()
     {
         _editingRollover = new InvestmentRollover
         {
             SourceInvestmentId = _investments?.FirstOrDefault()?.Id ?? 0,
-            DestinationInvestmentId = _investments?.FirstOrDefault()?.Id ?? 0
+            DestinationInvestmentId = _investments?.FirstOrDefault()?.Id ?? 0,
+            ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0
         };
         IsModalOpen = true;
     }
@@ -145,7 +154,8 @@ else
             DestinationInvestmentId = roll.DestinationInvestmentId,
             Amount = roll.Amount,
             Year = roll.Year,
-            RolloverType = roll.RolloverType
+            RolloverType = roll.RolloverType,
+            ScenarioId = roll.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Pages/Investments.razor
+++ b/Website/Pages/Investments.razor
@@ -3,6 +3,7 @@
 @using RetirementPlanner.Services
 @inject IInvestmentService InvestmentService
 @inject IPersonService PersonService
+@inject IScenarioService ScenarioService
 
 <h1 class="text-2xl font-bold mb-4">Investments</h1>
 
@@ -157,6 +158,7 @@ else
 @code {
     private List<Investment>? _investments;
     private List<Person>? _people;
+    private List<Scenario>? _scenarios;
     private Investment _editingInvestment = new();
     private bool IsModalOpen;
     private bool ShowRmdStartAge =>
@@ -167,6 +169,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadPeople();
         await LoadInvestments();
     }
@@ -174,6 +177,11 @@ else
     private async Task LoadInvestments()
     {
         _investments = await InvestmentService.GetAllAsync();
+    }
+
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
     }
 
     private async Task LoadPeople()
@@ -185,7 +193,8 @@ else
     {
         _editingInvestment = new Investment
         {
-            PersonId = _people?.FirstOrDefault()?.Id ?? 0
+            PersonId = _people?.FirstOrDefault()?.Id ?? 0,
+            ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0
         };
         IsModalOpen = true;
     }
@@ -209,6 +218,7 @@ else
             RequiresRMD = investment.RequiresRMD,
             RMDStartAge = investment.RMDStartAge,
             PersonId = investment.PersonId
+            ,ScenarioId = investment.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Pages/Scenarios.razor
+++ b/Website/Pages/Scenarios.razor
@@ -1,3 +1,160 @@
 @page "/scenarios"
+@using RetirementPlanner.Models
+@using RetirementPlanner.Services
+@inject IScenarioService ScenarioService
+
 <h1 class="text-2xl font-bold mb-4">Scenarios</h1>
-<p>Scenario management will be implemented here.</p>
+
+<button class="px-4 py-2 mb-2 bg-blue-600 text-white rounded" @onclick="OpenAddModal">Add Scenario</button>
+
+@if (_scenarios is null)
+{
+    <p>Loading...</p>
+}
+else if (_scenarios.Count == 0)
+{
+    <p>No scenarios defined.</p>
+}
+else
+{
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+            @foreach (var scenario in _scenarios)
+            {
+                <tr>
+                    <td class="px-3 py-2">@scenario.Name</td>
+                    <td class="px-3 py-2 text-right space-x-2">
+                        <button class="text-blue-500" @onclick="() => OpenEditModal(scenario)">Edit</button>
+                        <button class="text-red-500" @onclick="() => DeleteScenario(scenario.Id)">Delete</button>
+                        <button class="text-green-600" @onclick="() => OpenCloneModal(scenario.Id)">Clone Investments</button>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@if (IsModalOpen)
+{
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
+        <div class="bg-white p-4 rounded shadow w-full max-w-md">
+            <h2 class="text-xl font-bold mb-2">@(_editingScenario.Id == 0 ? "Add" : "Edit") Scenario</h2>
+            <EditForm Model="_editingScenario" OnValidSubmit="SaveScenario">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                <div class="mb-2">
+                    <label class="form-label">Name</label>
+                    <InputText class="form-input" @bind-Value="_editingScenario.Name" />
+                </div>
+                <div class="flex justify-end space-x-2">
+                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
+                    <button type="button" class="px-4 py-2 bg-gray-300 rounded" @onclick="CloseModal">Cancel</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@if (IsCloneModalOpen && _scenarios != null)
+{
+    <div class="fixed inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
+        <div class="bg-white p-4 rounded shadow w-full max-w-md">
+            <h2 class="text-xl font-bold mb-2">Clone Investments</h2>
+            <div class="mb-2">
+                <label class="form-label">Clone from scenario</label>
+                <InputSelect class="form-input" @bind-Value="_selectedSourceScenarioId">
+                    @foreach (var sc in _scenarios.Where(s => s.Id != _cloneTargetScenarioId))
+                    {
+                        <option value="@sc.Id">@sc.Name</option>
+                    }
+                </InputSelect>
+            </div>
+            <div class="flex justify-end space-x-2">
+                <button class="px-4 py-2 bg-blue-600 text-white rounded" @onclick="CloneInvestments">Clone</button>
+                <button class="px-4 py-2 bg-gray-300 rounded" @onclick="CloseCloneModal">Cancel</button>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Scenario>? _scenarios;
+    private Scenario _editingScenario = new();
+    private bool IsModalOpen;
+    private bool IsCloneModalOpen;
+    private int _cloneTargetScenarioId;
+    private int _selectedSourceScenarioId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadScenarios();
+    }
+
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
+    }
+
+    private void OpenAddModal()
+    {
+        _editingScenario = new Scenario();
+        IsModalOpen = true;
+    }
+
+    private void OpenEditModal(Scenario scenario)
+    {
+        _editingScenario = new Scenario
+        {
+            Id = scenario.Id,
+            Name = scenario.Name
+        };
+        IsModalOpen = true;
+    }
+
+    private async Task SaveScenario()
+    {
+        if (_editingScenario.Id == 0)
+        {
+            await ScenarioService.AddAsync(_editingScenario);
+        }
+        else
+        {
+            await ScenarioService.UpdateAsync(_editingScenario);
+        }
+
+        await LoadScenarios();
+        CloseModal();
+    }
+
+    private async Task DeleteScenario(int id)
+    {
+        await ScenarioService.DeleteAsync(id);
+        await LoadScenarios();
+    }
+
+    private void OpenCloneModal(int targetScenarioId)
+    {
+        _cloneTargetScenarioId = targetScenarioId;
+        _selectedSourceScenarioId = _scenarios?.FirstOrDefault(s => s.Id != targetScenarioId)?.Id ?? 0;
+        IsCloneModalOpen = true;
+    }
+
+    private async Task CloneInvestments()
+    {
+        if (_selectedSourceScenarioId > 0)
+        {
+            await ScenarioService.CloneInvestmentsAsync(_selectedSourceScenarioId, _cloneTargetScenarioId);
+        }
+        CloseCloneModal();
+        await LoadScenarios();
+    }
+
+    private void CloseModal() => IsModalOpen = false;
+    private void CloseCloneModal() => IsCloneModalOpen = false;
+}

--- a/Website/Pages/SurplusAllocations.razor
+++ b/Website/Pages/SurplusAllocations.razor
@@ -3,6 +3,7 @@
 @using RetirementPlanner.Services
 @inject ISurplusAllocationService SurplusAllocationService
 @inject IInvestmentService InvestmentService
+@inject IScenarioService ScenarioService
 
 <h1 class="text-2xl font-bold mb-4">Surplus Allocations</h1>
 
@@ -83,11 +84,13 @@ else
 @code {
     private List<SurplusAllocationConfig>? _allocations;
     private List<Investment>? _investments;
+    private List<Scenario>? _scenarios;
     private SurplusAllocationConfig _editingAllocation = new();
     private bool IsModalOpen;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadInvestments();
         await LoadAllocations();
     }
@@ -102,11 +105,17 @@ else
         _investments = await InvestmentService.GetAllAsync();
     }
 
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
+    }
+
     private void OpenAddModal()
     {
         _editingAllocation = new SurplusAllocationConfig
         {
-            InvestmentId = _investments?.FirstOrDefault()?.Id ?? 0
+            InvestmentId = _investments?.FirstOrDefault()?.Id ?? 0,
+            ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0
         };
         IsModalOpen = true;
     }
@@ -117,7 +126,8 @@ else
         {
             Id = alloc.Id,
             InvestmentId = alloc.InvestmentId,
-            AllocationPercentage = alloc.AllocationPercentage
+            AllocationPercentage = alloc.AllocationPercentage,
+            ScenarioId = alloc.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Pages/TaxBrackets.razor
+++ b/Website/Pages/TaxBrackets.razor
@@ -2,6 +2,7 @@
 @using RetirementPlanner.Models
 @using RetirementPlanner.Services
 @inject ITaxBracketService TaxBracketService
+@inject IScenarioService ScenarioService
 
 <h1 class="text-2xl font-bold mb-4">Tax Brackets</h1>
 <button class="px-4 py-2 mb-2 bg-blue-600 text-white rounded" @onclick="OpenAddModal">Add Tax Bracket</button>
@@ -109,11 +110,13 @@ else
 
 @code {
     private List<TaxBracket>? _brackets;
+    private List<Scenario>? _scenarios;
     private TaxBracket _editingBracket = new();
     private bool IsModalOpen;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadScenarios();
         await LoadBrackets();
     }
 
@@ -122,9 +125,17 @@ else
         _brackets = await TaxBracketService.GetAllAsync();
     }
 
+    private async Task LoadScenarios()
+    {
+        _scenarios = await ScenarioService.GetAllAsync();
+    }
+
     private void OpenAddModal()
     {
-        _editingBracket = new TaxBracket();
+        _editingBracket = new TaxBracket
+        {
+            ScenarioId = _scenarios?.FirstOrDefault()?.Id ?? 0
+        };
         IsModalOpen = true;
     }
 
@@ -139,7 +150,8 @@ else
             MaxIncome = bracket.MaxIncome,
             Rate = bracket.Rate,
             Threshold = bracket.Threshold,
-            State = bracket.State
+            State = bracket.State,
+            ScenarioId = bracket.ScenarioId
         };
         IsModalOpen = true;
     }

--- a/Website/Program.cs
+++ b/Website/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddScoped<IAssetService, AssetService>();
 builder.Services.AddScoped<ITaxBracketService, TaxBracketService>();
 builder.Services.AddScoped<IInvestmentRolloverService, InvestmentRolloverService>();
 builder.Services.AddScoped<ISurplusAllocationService, SurplusAllocationService>();
+builder.Services.AddScoped<IScenarioService, ScenarioService>();
 
 var app = builder.Build();
 

--- a/Website/Services/IScenarioService.cs
+++ b/Website/Services/IScenarioService.cs
@@ -1,0 +1,20 @@
+using RetirementPlanner.Models;
+
+namespace RetirementPlanner.Services;
+
+/// <summary>
+/// Provides CRUD operations for scenarios and helper methods for cloning data between scenarios.
+/// </summary>
+public interface IScenarioService
+{
+    Task<List<Scenario>> GetAllAsync();
+    Task<Scenario?> GetByIdAsync(int id);
+    Task<Scenario> AddAsync(Scenario entity);
+    Task UpdateAsync(Scenario entity);
+    Task DeleteAsync(int id);
+
+    /// <summary>
+    /// Clone all investments from the source scenario to the target scenario.
+    /// </summary>
+    Task CloneInvestmentsAsync(int sourceScenarioId, int targetScenarioId);
+}

--- a/Website/Services/ScenarioService.cs
+++ b/Website/Services/ScenarioService.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using RetirementPlanner.Data;
+using RetirementPlanner.Models;
+
+namespace RetirementPlanner.Services;
+
+/// <summary>
+/// EF Core backed implementation of <see cref="IScenarioService"/>.
+/// </summary>
+public class ScenarioService : IScenarioService
+{
+    private readonly RetirementPlannerContext _context;
+
+    public ScenarioService(RetirementPlannerContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<Scenario>> GetAllAsync()
+    {
+        return await _context.Scenarios.ToListAsync();
+    }
+
+    public async Task<Scenario?> GetByIdAsync(int id)
+    {
+        return await _context.Scenarios.FindAsync(id);
+    }
+
+    public async Task<Scenario> AddAsync(Scenario entity)
+    {
+        Validator.ValidateObject(entity, new ValidationContext(entity), true);
+        _context.Scenarios.Add(entity);
+        await _context.SaveChangesAsync();
+        return entity;
+    }
+
+    public async Task UpdateAsync(Scenario entity)
+    {
+        Validator.ValidateObject(entity, new ValidationContext(entity), true);
+        _context.Scenarios.Update(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var existing = await _context.Scenarios.FindAsync(id);
+        if (existing is null)
+        {
+            throw new KeyNotFoundException($"Scenario {id} not found");
+        }
+
+        _context.Scenarios.Remove(existing);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task CloneInvestmentsAsync(int sourceScenarioId, int targetScenarioId)
+    {
+        if (sourceScenarioId == targetScenarioId) return;
+
+        var sourceInvestments = await _context.Investments
+            .Include(i => i.DistributionConfig)
+            .Where(i => i.ScenarioId == sourceScenarioId)
+            .ToListAsync();
+
+        var existingNames = await _context.Investments
+            .Where(i => i.ScenarioId == targetScenarioId)
+            .Select(i => i.Name)
+            .ToListAsync();
+
+        foreach (var inv in sourceInvestments)
+        {
+            var newName = GenerateUniqueName(inv.Name, existingNames);
+            existingNames.Add(newName);
+
+            var clone = new Investment
+            {
+                Name = newName,
+                ScenarioId = targetScenarioId,
+                InvestmentType = inv.InvestmentType,
+                CurrentBalance = inv.CurrentBalance,
+                ExpectedDividendYield = inv.ExpectedDividendYield,
+                ExpectedGrowthRate = inv.ExpectedGrowthRate,
+                ExpectedReturnOfCapitalRate = inv.ExpectedReturnOfCapitalRate,
+                ExpenseRatio = inv.ExpenseRatio,
+                ExpectedTurnoverRate = inv.ExpectedTurnoverRate,
+                IsFederalTaxExempt = inv.IsFederalTaxExempt,
+                IsStateTaxExempt = inv.IsStateTaxExempt,
+                WithdrawalPriority = inv.WithdrawalPriority,
+                RequiresRMD = inv.RequiresRMD,
+                RMDStartAge = inv.RMDStartAge,
+                PersonId = inv.PersonId,
+                DistributionConfig = inv.DistributionConfig
+                    .Select(d => new InvestmentDistributionConfig
+                    {
+                        Category = d.Category,
+                        AnnualPercentage = d.AnnualPercentage
+                    }).ToList()
+            };
+
+            _context.Investments.Add(clone);
+        }
+
+        await _context.SaveChangesAsync();
+    }
+
+    private static string GenerateUniqueName(string baseName, ICollection<string> existingNames)
+    {
+        if (!existingNames.Contains(baseName))
+            return baseName;
+
+        var counter = 1;
+        var newName = $"{baseName} ({counter})";
+        while (existingNames.Contains(newName))
+        {
+            counter++;
+            newName = $"{baseName} ({counter})";
+        }
+        return newName;
+    }
+}


### PR DESCRIPTION
## Summary
- add `Scenario` model to store simulation settings
- connect assets, incomes, expenses and other entities to a scenario
- register and implement `IScenarioService` with investment cloning and unique naming
- add basic scenario management page with investment cloning UI
- update existing pages to assign new records to a scenario

## Testing
- `dotnet build MoMoney.sln --configuration Release --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687550a178e88324891ab896c2a53b9a